### PR TITLE
Add missing encoder code to Halcyon Elora rev2

### DIFF
--- a/keyboards/splitkb/halcyon/elora/keymaps/default_hlc/keymap.c
+++ b/keyboards/splitkb/halcyon/elora/keymaps/default_hlc/keymap.c
@@ -259,3 +259,39 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 //     ),
 //
 };
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+
+    if (index == 0) {
+        // Volume control
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        // Volume control
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 2) {
+        // Page up/Page down
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 3) {
+        // Page up/Page down
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}
+#endif


### PR DESCRIPTION
The default Halcyon Elora keymap was missing code for the encoder, this is copied from the Kyria keymap.