### PR TITLE
Fix failing compilation due to missing stdbool.h

### DIFF
--- a/users/halcyon_modules/splitkb/halcyon.h
+++ b/users/halcyon_modules/splitkb/halcyon.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 typedef enum module {
     none,
     hlc_none,


### PR DESCRIPTION
When targeting the elora r2 with TFT module, there are several compilation errors.

    qmk compile -kb splitkb/halcyon/elora/rev2 -km vial_hlc -e HLC_TFT_DISPLAY=1 -e TARGET=splitkb_halcyon_elora_rev2_vial_hlc_display
    arm-none-eabi-gcc (Arch Repository) 14.2.0
    [snip]
    Compiling: /home/foo/git/vial/splitkb-qmk_userspace/users/halcyon_modules/splitkb/hlc_tft_display/hlc_tft_display.cIn file included from /home/kristof/git/vial/splitkb-qmk_userspace/users/halcyon_modules/splitkb/hlc_tft_display/hlc_tft_display.c:4:
    /home/kristof/git/vial/splitkb-qmk_userspace/users/halcyon_modules/splitkb/halcyon.h:16:1: error: unknown type name 'bool'
       16 | bool module_post_init_kb(void);
          | ^~~~
    /home/foo/git/vial/splitkb-qmk_userspace/users/halcyon_modules/splitkb/halcyon.h:1:1: note: 'bool' is defined in header '<stdbool.h>'; this is probably fixable by adding '#include <stdbool.h>'
      +++ |+#include <stdbool.h>

qmk repo hash: 86badb394e