### PR TITLE
fix: Allow definition of ENCODER_RESOLUTIONS

### DIFF
--- a/users/halcyon_modules/splitkb/hlc_encoder/config_rev2.h
+++ b/users/halcyon_modules/splitkb/hlc_encoder/config_rev2.h
@@ -8,5 +8,7 @@
 #if defined(KEYBOARD_splitkb_halcyon_ferris_rev1)
 #define ENCODER_RESOLUTION 4
 #else
+#ifndef ENCODER_RESOLUTIONS
 #define ENCODER_RESOLUTIONS { 2, 4 }
+#endif
 #endif


### PR DESCRIPTION
This PR fixes a problem where you cannot define the ENCODER_RESOLUTIONS map/dictionary in your config because it has already been defined elsewhere.

_Note: I think, the resolution for the right encoder should also be 2. At least, that's how it works on my Halcyon Lily58. I kept the default, since I'm not sure if that is intentional or just an oversight._